### PR TITLE
Table default sorts by date: components/JobTable.tsx changed

### DIFF
--- a/app/components/JobTable.tsx
+++ b/app/components/JobTable.tsx
@@ -170,11 +170,12 @@ export default function JobTable({ descriptions }: JobTableProps) {
 
   function formatDate(date: Date) {
     const month = date.getMonth() + 1; // getMonth() is zero-based
-    const day = date.getDate();
+    let day = date.getDate();
     const year = date.getFullYear();
 
-    // Format the date as mm/dd/yyyy
-    return `${month}/${day}/${year}`;
+    // Format the date as mm/dd/yyyy'
+    console.log(day.toString().length === 2 ? "0" + day.toString() : day)
+    return `${month}/${day.toString().length === 1 ? "0" + day.toString() : day}/${year}`;
   }
 
   /**
@@ -231,6 +232,9 @@ export default function JobTable({ descriptions }: JobTableProps) {
         columns={columns}
         onRowClick={handleRowClick}
         initialState={{
+          sorting: {
+            sortModel: [{ field: 'job_scraped_date', sort: 'desc' }], 
+          },
           pagination: {
             paginationModel: {
               pageSize: 25,


### PR DESCRIPTION
Added sorting method and added a turnery to JobTable() to facilitate date sorting

Issue: 
Jobs were being sorted by date but when the values were converted to strings, the dates that were between the 1st and the 9th were showing up before later dates. So I added some logic to slap a "0" in front of the 1-9 dates such that the sorting method was effective. 